### PR TITLE
Make meta available in javascript and add shortName to program if it is missing.

### DIFF
--- a/includes/head.php
+++ b/includes/head.php
@@ -98,3 +98,7 @@ function rootPath()
 <meta property="twitter:image" content="https://iacr.org/img/logo/iacr_wordmark_twitter.png" />
 <!-- apple format for iMessage and search -->
 <link rel="apple-touch-icon" href="https://iacr.org/img/logo/iacrlogo_small.png">
+<script>
+  // This makes the meta variables available in javascript as well as PHP.
+  <?php echo "var meta=" . json_encode($META, JSON_PRETTY_PRINT) . ";"?>
+</script>

--- a/js/program.js
+++ b/js/program.js
@@ -90,6 +90,9 @@ function scrollToSession() {
 function drawProgram() {
   /* Every timeslot gets a tabbedSessions variable when
      it is drawn, to detect which ones should use tabs. */
+  if (!Object.hasOwn(currentProgram.config.timezone, 'shortName')) {
+    currentProgram.config.timezone.shortName = meta.city;
+  }
   let days = currentProgram['days'];
   for (var i = 0; i < days.length; i++) {
     var timeslots = days[i]['timeslots'];

--- a/js/program.js
+++ b/js/program.js
@@ -90,8 +90,14 @@ function scrollToSession() {
 function drawProgram() {
   /* Every timeslot gets a tabbedSessions variable when
      it is drawn, to detect which ones should use tabs. */
+  // Populate the shortName in the program if it wasn't already set.
   if (!Object.hasOwn(currentProgram.config.timezone, 'shortName')) {
-    currentProgram.config.timezone.shortName = meta.city;
+    // If the metadata.json doesn't have a city set, we use 'Local'
+    if (meta.city) {
+      currentProgram.config.timezone.shortName = meta.city;
+    } else {
+      currentProgram.config.timezone.shortName = 'Local'
+    }
   }
   let days = currentProgram['days'];
   for (var i = 0; i < days.length; i++) {

--- a/program.php
+++ b/program.php
@@ -35,6 +35,9 @@
       font-size: 80%;
     }
   </style>
+  <script>
+  <?php echo "var meta=" . json_encode($META, JSON_PRETTY_PRINT) . ";"?>
+  </script>
 </head>
 
 <body>

--- a/program.php
+++ b/program.php
@@ -35,9 +35,6 @@
       font-size: 80%;
     }
   </style>
-  <script>
-  <?php echo "var meta=" . json_encode($META, JSON_PRETTY_PRINT) . ";"?>
-  </script>
 </head>
 
 <body>


### PR DESCRIPTION
This does two things:
1. make the `$META` variable from php also available in javascript as the variable `meta`. This is available in all pages because it is in `includes/head.php`
2. use the `meta` variable to populate the `shortName` if it was not already set in the `program.json`. This way we can avoid changing the program editor to require this.